### PR TITLE
Use placeholders in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Skeleton Theme
+# Contributing to <THEME_NAME>
 
 ## How to contribute
 
@@ -17,7 +17,7 @@ For your contribution to be accepted, you'll need to sign the [Shopify Contribut
 
 ## Steps to contribute
 
-1. Fork the repository: [https://github.com/Shopify/skeleton-theme/fork](https://github.com/Shopify/skeleton-theme/fork)
+1. Fork the repository: [<REPOSITORY_FORK_URL>](<REPOSITORY_FORK_URL>)
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Commit your changes: `git commit -am 'Add some feature'`
 4. Push to your branch: `git push origin my-new-feature`

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <h1 align="center" style="position: relative;">
   <br>
-    <img src="./assets/shoppy-x-ray.svg" alt="logo" width="200">
+    <img src="./assets/<LOGO_PLACEHOLDER>" alt="logo" width="200">
   <br>
-  Shopify Skeleton Theme
+  <THEME_NAME>
 </h1>
 
 A minimal, carefully structured Shopify theme designed to help you quickly get started. Designed with modularity, maintainability, and Shopify's best practices in mind.
 
 <p align="center">
   <a href="./LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License"></a>
-  <a href="./actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Shopify/skeleton-theme/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="./actions/workflows/ci.yml"><img alt="CI" src="https://github.com/<USER>/<REPO>/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 
 ## Getting started
@@ -29,9 +29,9 @@ If you use VS Code:
 Clone this repository using Git or Shopify CLI:
 
 ```bash
-git clone git@github.com:Shopify/skeleton-theme.git
+git clone <REPOSITORY_URL>
 # or
-shopify theme init
+shopify theme init <THEME_NAME>
 ```
 
 ### Preview
@@ -62,9 +62,9 @@ To learn more, refer to the [theme architecture documentation](https://shopify.d
 
 [Templates](https://shopify.dev/docs/storefronts/themes/architecture/templates#template-types) control what's rendered on each type of page in a theme.
 
-The Skeleton Theme scaffolds [JSON templates](https://shopify.dev/docs/storefronts/themes/architecture/templates/json-templates) to make it easy for merchants to customize their store.
+The <THEME_NAME> scaffolds [JSON templates](https://shopify.dev/docs/storefronts/themes/architecture/templates/json-templates) to make it easy for merchants to customize their store.
 
-None of the template types are required, and not all of them are included in the Skeleton Theme. Refer to the [template types reference](https://shopify.dev/docs/storefronts/themes/architecture/templates#template-types) for a full list.
+None of the template types are required, and not all of them are included in the <THEME_NAME>. Refer to the [template types reference](https://shopify.dev/docs/storefronts/themes/architecture/templates#template-types) for a full list.
 
 ### Sections
 
@@ -147,14 +147,14 @@ For CSS and JavaScript, we recommend using the [`{% stylesheet %}`](https://shop
 
 ### `critical.css`
 
-The Skeleton Theme explicitly separates essential CSS necessary for every page into a dedicated `critical.css` file.
+The <THEME_NAME> explicitly separates essential CSS necessary for every page into a dedicated `critical.css` file.
 
 ## Contributing
 
-We're excited for your contributions to the Skeleton Theme! This repository aims to remain as lean, lightweight, and fundamental as possible, and we kindly ask your contributions to align with this intention.
+We're excited for your contributions to the <THEME_NAME>! This repository aims to remain as lean, lightweight, and fundamental as possible, and we kindly ask your contributions to align with this intention.
 
 Visit our [CONTRIBUTING.md](./CONTRIBUTING.md) for a detailed overview of our process, guidelines, and recommendations.
 
 ## License
 
-Skeleton Theme is open-sourced under the [MIT](./LICENSE.md) License.
+<THEME_NAME> is open-sourced under the [MIT](./LICENSE.md) License.

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "theme_info",
-    "theme_name": "Skeleton",
+    "theme_name": "<THEME_NAME>",
     "theme_version": "0.1.0",
     "theme_author": "Shopify",
     "theme_documentation_url": "https://help.shopify.com/manual/online-store/themes",
@@ -118,6 +118,13 @@
         "id": "whatsapp_message",
         "label": "WhatsApp default message"
       }
+    ]
+  },
+  {
+    "name": "Branding",
+    "settings": [
+      { "type": "image_picker", "id": "logo", "label": "Logo" },
+      { "type": "image_picker", "id": "favicon", "label": "Favicon" }
     ]
   },
   {

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -24,16 +24,28 @@
 
   <div class="footer__trust">
     <div class="trust-item">
-      <img src="{{ 'icon-shipping.svg' | asset_url }}" alt="Free shipping">
-      <span>Free shipping</span>
+      {% if section.settings.shipping_icon %}
+        {{ section.settings.shipping_icon | image_url: width: 20 | image_tag: alt: section.settings.shipping_text }}
+      {% else %}
+        <img src="{{ 'icon-shipping.svg' | asset_url }}" alt="{{ section.settings.shipping_text }}">
+      {% endif %}
+      <span>{{ section.settings.shipping_text }}</span>
     </div>
     <div class="trust-item">
-      <img src="{{ 'icon-cod.svg' | asset_url }}" alt="Cash on delivery">
-      <span>COD available</span>
+      {% if section.settings.cod_icon %}
+        {{ section.settings.cod_icon | image_url: width: 20 | image_tag: alt: section.settings.cod_text }}
+      {% else %}
+        <img src="{{ 'icon-cod.svg' | asset_url }}" alt="{{ section.settings.cod_text }}">
+      {% endif %}
+      <span>{{ section.settings.cod_text }}</span>
     </div>
     <div class="trust-item">
-      <img src="{{ 'icon-returns.svg' | asset_url }}" alt="Easy returns">
-      <span>Easy returns</span>
+      {% if section.settings.returns_icon %}
+        {{ section.settings.returns_icon | image_url: width: 20 | image_tag: alt: section.settings.returns_text }}
+      {% else %}
+        <img src="{{ 'icon-returns.svg' | asset_url }}" alt="{{ section.settings.returns_text }}">
+      {% endif %}
+      <span>{{ section.settings.returns_text }}</span>
     </div>
   </div>
 </footer>
@@ -112,69 +124,13 @@
       "id": "show_payment_icons",
       "label": "t:labels.show_payment_icons",
       "default": true
-    }
-  ]
-}
-{% endschema %}
-
-  }
-  footer a {
-    text-decoration: none;
-    color: var(--color-foreground);
-  }
-  footer .footer__links,
-  footer .footer__payment,
-  footer .footer__locale {
-    display: flex;
-    gap: 1rem;
-  }
-  footer .footer__trust {
-    display: flex;
-    gap: 1rem;
-    margin-top: 1rem;
-  }
-  footer .trust-item {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-  }
-{% endstylesheet %}
-
-{% schema %}
-{
-  "name": "t:general.footer",
-  "settings": [
-    {
-      "type": "range",
-      "id": "top_padding",
-      "label": "Top padding",
-      "min": 0,
-      "max": 100,
-      "step": 4,
-      "unit": "px",
-      "default": 0
     },
-    {
-      "type": "range",
-      "id": "bottom_padding",
-      "label": "Bottom padding",
-      "min": 0,
-      "max": 100,
-      "step": 4,
-      "unit": "px",
-      "default": 0
-    },
-    {
-      "type": "link_list",
-      "id": "menu",
-      "label": "t:labels.menu"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_payment_icons",
-      "label": "t:labels.show_payment_icons",
-      "default": true
-    }
+    { "type": "image_picker", "id": "shipping_icon", "label": "Shipping icon" },
+    { "type": "text", "id": "shipping_text", "label": "Shipping text", "default": "Free shipping" },
+    { "type": "image_picker", "id": "cod_icon", "label": "COD icon" },
+    { "type": "text", "id": "cod_text", "label": "COD text", "default": "COD available" },
+    { "type": "image_picker", "id": "returns_icon", "label": "Returns icon" },
+    { "type": "text", "id": "returns_text", "label": "Returns text", "default": "Easy returns" }
   ]
 }
 {% endschema %}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,6 +1,12 @@
 <header style="padding-top: {{ section.settings.top_padding }}px; padding-bottom: {{ section.settings.bottom_padding }}px;">
   <h2 class="header__title">
-    {{ shop.name | link_to: routes.root_url }}
+    <a href="{{ routes.root_url }}">
+      {% if settings.logo %}
+        {{ settings.logo | image_url: width: 200 | image_tag: alt: shop.name }}
+      {% else %}
+        {{ shop.name }}
+      {% endif %}
+    </a>
   </h2>
 
   <div class="header__menu">
@@ -80,6 +86,11 @@
       "step": 4,
       "unit": "px",
       "default": 0
+    },
+    {
+      "type": "image_picker",
+      "id": "logo",
+      "label": "Logo"
     },
     {
       "type": "link_list",

--- a/sections/hello-world.liquid
+++ b/sections/hello-world.liquid
@@ -9,7 +9,7 @@
       <h1>Hello, World!</h1>
 
       <p class="welcome-description">
-        The Skeleton theme is a minimal, carefully structured Shopify theme designed to help you quickly get started.
+        The <THEME_NAME> is a minimal, carefully structured Shopify theme designed to help you quickly get started.
         Designed with modularity, maintainability, and Shopify's best practices in mind.
       </p>
 
@@ -19,7 +19,11 @@
       </p>
     </div>
     <div class="icon">
-      <img src="{{ 'shoppy-x-ray.svg' | asset_url }}" width="300" height="300" loading="lazy">
+      {% if section.settings.illustration %}
+        {{ section.settings.illustration | image_url: width: 300 | image_tag: alt: 'Illustration', loading: 'lazy' }}
+      {% else %}
+        <img src="{{ 'shoppy-x-ray.svg' | asset_url }}" width="300" height="300" loading="lazy">
+      {% endif %}
     </div>
   </div>
 </div>
@@ -145,6 +149,11 @@
       "step": 4,
       "unit": "px",
       "default": 0
+    },
+    {
+      "type": "image_picker",
+      "id": "illustration",
+      "label": "Illustration"
     },
     {
       "type": "range",


### PR DESCRIPTION
## Summary
- switch README and CONTRIBUTING docs to use placeholders instead of example repository details
- add settings so buyers can upload their own logo and trust icons

## Testing
- `theme-check` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ed1840a8c83228e22c8d2303f07f5