### PR TITLE
Fix missing img dimensions in footer

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -24,15 +24,15 @@
 
   <div class="footer__trust">
     <div class="trust-item">
-      <img src="{{ 'icon-shipping.svg' | asset_url }}" alt="Free shipping">
+      <img src="{{ 'icon-shipping.svg' | asset_url }}" alt="Free shipping" width="48" height="48">
       <span>Free shipping</span>
     </div>
     <div class="trust-item">
-      <img src="{{ 'icon-cod.svg' | asset_url }}" alt="Cash on delivery">
+      <img src="{{ 'icon-cod.svg' | asset_url }}" alt="Cash on delivery" width="48" height="48">
       <span>COD available</span>
     </div>
     <div class="trust-item">
-      <img src="{{ 'icon-returns.svg' | asset_url }}" alt="Easy returns">
+      <img src="{{ 'icon-returns.svg' | asset_url }}" alt="Easy returns" width="48" height="48">
       <span>Easy returns</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add width and height attributes to footer trust icons

## Testing
- `theme-check`

------
https://chatgpt.com/codex/tasks/task_e_684efe2042f8832298a85022d07410d3